### PR TITLE
Add Java9 support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,12 +17,129 @@ pipeline {
 
     stages {
 
-        stage("Java8") {
-            tools {
-                jdk 'jdk8'
-            }
-            steps {
-                sh "mvn clean package"
+        stage('X-Platform Tests') {
+            parallel {
+
+                stage('Windows Java 8') {
+                    agent {
+                        node {
+                            label 'windows && x64'
+                            customWorkspace "${BUILD_TAG}-win8"
+                        }
+                    }
+                    tools {
+                        jdk 'jdk8'
+                    }
+                    steps {
+                        bat 'mvn clean package -PnoJava9'
+                    }
+                    post {
+                        always {
+                            cleanWs()
+                        }
+                    }
+                }
+
+                stage('Linux Java 8') {
+                    agent {
+                        node {
+                            label 'linux && x64'
+                            customWorkspace "${BUILD_TAG}-lin8"
+                        }
+                    }
+                    tools {
+                        jdk 'jdk8'
+                    }
+                    steps {
+                        sh 'mvn clean package -PnoJava9'
+                    }
+                    post {
+                        always {
+                            cleanWs()
+                        }
+                    }
+                }
+
+                stage('OSX Java 8') {
+                    agent {
+                        node {
+                            label 'osx && x64'
+                            customWorkspace "${BUILD_TAG}-osx8"
+                        }
+                    }
+                    tools {
+                        jdk 'jdk8'
+                    }
+                    steps {
+                        sh 'mvn clean package -PnoJava9'
+                    }
+                    post {
+                        always {
+                            cleanWs()
+                        }
+                    }
+                }
+
+                stage('Windows Java 9') {
+                    agent {
+                        node {
+                            label 'windows && x64'
+                            customWorkspace "${BUILD_TAG}-win9"
+                        }
+                    }
+                    tools {
+                        jdk 'jdk9'
+                    }
+                    steps {
+                        bat 'mvn clean package'
+                    }
+                    post {
+                        always {
+                            cleanWs()
+                        }
+                    }
+                }
+
+                stage('Linux Java 9') {
+                    agent {
+                        node {
+                            label 'linux && x64'
+                            customWorkspace "${BUILD_TAG}-lin9"
+                        }
+                    }
+                    tools {
+                        jdk 'jdk9'
+                    }
+                    steps {
+                        sh 'mvn clean package'
+                    }
+                    post {
+                        always {
+                            cleanWs()
+                        }
+                    }
+                }
+
+                stage('OSX Java 9') {
+                    agent {
+                        node {
+                            label 'osx && x64'
+                            customWorkspace "${BUILD_TAG}-osx9"
+                        }
+                    }
+                    tools {
+                        jdk 'jdk9'
+                    }
+                    steps {
+                        sh 'mvn clean package'
+                    }
+                    post {
+                        always {
+                            cleanWs()
+                        }
+                    }
+                }
+
             }
         }
 

--- a/README.adoc
+++ b/README.adoc
@@ -7,3 +7,17 @@ This `MatlabTools` repo is intended to be an open source collection of some of o
 `MatlabTools::IO` is a library that allows importing and exporting MATLAB's Level 5 MAT-Files. The Level 5 format is also known as `MAT-File Version 7` and has been the default format for `.mat` and `.fig` files since `MATLAB R14` which was released in https://en.wikipedia.org/wiki/MATLAB#Release_history[2004].
 
 For more information and usage examples, please refer to the sub-readme at link:./io[MatlabTools::IO].
+
+== Building Sources
+
+The created sources include Java 9's `module-info.java`, but are otherwise backwards compatible with Java 6. The contained unit tests may use Java 8 syntax, so the project needs to be compiled with at least JDK 8.
+
+Building with JDK 9 and above
+
+    mvn package
+
+Building with JDK 8
+
+    mvn package -PnoJava9
+
+For more information, please check the CI build-script link:Jenkinsfile[]

--- a/io/src/main/java/module-info.java
+++ b/io/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module us.hebi.matlab.io {
+
+    requires jdk.unsupported;
+
+    exports us.hebi.matlab.io.mat;
+    exports us.hebi.matlab.io.types;
+    exports us.hebi.matlab.io.experimental;
+
+}

--- a/io/src/main/java/us/hebi/matlab/common/memory/Resources.java
+++ b/io/src/main/java/us/hebi/matlab/common/memory/Resources.java
@@ -1,22 +1,105 @@
 package us.hebi.matlab.common.memory;
 
-import sun.nio.ch.DirectBuffer;
+import us.hebi.matlab.common.util.PlatformInfo;
+
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
 
 /**
- * Helps to clean up native memory. In Java 8 and below this
- * requires internal APIs that got removed in Java9. For
- * Java9 this class can be replaced using the appropriate
- * <p>
- * {@see java.lang.ref.Cleaner} API.
+ * Helps to free native memory of DirectBuffers. In Java 8 and below this
+ * requires internal APIs that got removed in Java9.
+ *
+ * Java9 later added a method to Unsafe to restore the functionality.
+ * See https://bugs.openjdk.java.net/browse/JDK-8171377
  *
  * @author Florian Enner < florian @ hebirobotics.com >
  * @since 31 Aug 2018
  */
 public class Resources {
 
-    public static void release(Object obj) {
-        if (obj instanceof DirectBuffer)
-            ((DirectBuffer) obj).cleaner().clean();
+    public static void release(ByteBuffer buffer) {
+        if (buffer.isDirect()) {
+            cleaner.freeDirectBuffer(buffer);
+        }
+    }
+
+    static {
+        int version = PlatformInfo.getJavaVersion();
+
+        if (version >= 9 && UnsafeAccess.isAvailable()) {
+            cleaner = new Java9Cleaner();
+
+        } else if (version < 9 && !PlatformInfo.isAndroid()) {
+            cleaner = new Java6Cleaner();
+
+        } else {
+            cleaner = new DisabledCleaner();
+        }
+    }
+
+    private static final Cleaner cleaner;
+
+    private interface Cleaner {
+        void freeDirectBuffer(ByteBuffer buffer);
+    }
+
+    private static class DisabledCleaner implements Cleaner {
+        @Override
+        public void freeDirectBuffer(ByteBuffer buffer) {
+        }
+    }
+
+    /**
+     * sun.nio.ch.DirectBuffer::cleaner()
+     * sun.misc.Cleaner::freeDirectBuffer()
+     */
+    private static class Java6Cleaner implements Cleaner {
+        @Override
+        public void freeDirectBuffer(ByteBuffer buffer) {
+            try {
+                cleanMethod.invoke(getCleanerMethod.invoke(buffer));
+            } catch (Exception e) {
+                throw new AssertionError("Java6Cleaner failed to free DirectBuffer", e);
+            }
+        }
+
+        Java6Cleaner() {
+            try {
+                getCleanerMethod = Class.forName("sun.nio.ch.DirectBuffer").getMethod("cleaner");
+                cleanMethod = Class.forName("sun.misc.Cleaner").getMethod("clean");
+            } catch (Exception e) {
+                throw new AssertionError("Java6Cleaner not available", e);
+            }
+        }
+
+        final Method getCleanerMethod;
+        final Method cleanMethod;
+
+    }
+
+    /**
+     * sun.misc.Unsafe::invokeCleaner(buffer)
+     */
+    private static class Java9Cleaner implements Cleaner {
+        @Override
+        public void freeDirectBuffer(ByteBuffer buffer) {
+            try {
+                INVOKE_CLEANER.invoke(UnsafeAccess.UNSAFE, buffer);
+            } catch (Exception e) {
+                throw new AssertionError("Java9Cleaner failed to free DirectBuffer", e);
+            }
+        }
+
+        Java9Cleaner() {
+            try {
+                INVOKE_CLEANER = UnsafeAccess.UNSAFE.getClass().getMethod("invokeCleaner", ByteBuffer.class);
+            } catch (Exception e) {
+                throw new AssertionError("Java9Cleaner not available", e);
+            }
+        }
+
+        final Method INVOKE_CLEANER;
+
     }
 
 }

--- a/io/src/main/java/us/hebi/matlab/common/memory/UnsafeAccess.java
+++ b/io/src/main/java/us/hebi/matlab/common/memory/UnsafeAccess.java
@@ -13,9 +13,9 @@ import java.security.PrivilegedExceptionAction;
  */
 class UnsafeAccess {
 
-    public static void requireUnsafe(){
+    public static void requireUnsafe() {
         // throws an exception if not available
-        if(!isAvailable())
+        if (!isAvailable())
             throw new AssertionError("Unsafe is not available on this platform");
     }
 
@@ -51,6 +51,5 @@ class UnsafeAccess {
     final static ByteOrder NATIVE_ORDER = ByteOrder.nativeOrder();
     final static Unsafe UNSAFE;
     final static long BYTE_ARRAY_OFFSET;
-
 
 }

--- a/io/src/main/java/us/hebi/matlab/common/util/PlatformInfo.java
+++ b/io/src/main/java/us/hebi/matlab/common/util/PlatformInfo.java
@@ -1,0 +1,81 @@
+package us.hebi.matlab.common.util;
+
+import java.util.Locale;
+
+/**
+ * Utility methods that provide information about the underlying platform.
+ *
+ * @author Florian Enner < florian @ hebirobotics.com >
+ * @since 19 Oct 2018
+ */
+public final class PlatformInfo {
+
+    public static boolean isWindows() {
+        return IS_WINDOWS;
+    }
+
+    public static boolean isUnix() {
+        return IS_UNIX;
+    }
+
+    public static boolean isMac() {
+        return IS_MAC;
+    }
+
+    public static boolean isAndroid() {
+        return IS_ANDROID;
+    }
+
+    /**
+     * @return {@code true} if the current execution is within MATLAB
+     */
+    public static boolean isMatlab() {
+        return IS_MATLAB;
+    }
+
+    public static boolean hasSecurityManager() {
+        return System.getSecurityManager() != null;
+    }
+
+    /**
+     * @return 6, 7, 8, 9, 10, 11, ...
+     */
+    public static int getJavaVersion() {
+        return JAVA_VERSION;
+    }
+
+    // Underlying OS (http://www.mkyong.com/java/how-to-detect-os-in-java-systemgetpropertyosname/)
+    private static final String OS = System.getProperty("os.name").toLowerCase(Locale.US);
+    private static final boolean IS_WINDOWS = OS.contains("win");
+    private static final boolean IS_MAC = OS.contains("mac");
+    private static final boolean IS_UNIX = OS.contains("nix") || OS.contains("nux") || OS.indexOf("aix") > 0;
+    private static final boolean IS_SOLARIS = OS.contains("sunos");
+
+    private static final boolean IS_ANDROID = "Dalvik".equals(System.getProperty("java.vm.name"));
+    private static final boolean IS_MATLAB = isMatlab0();
+    private static final int JAVA_VERSION = getMajorJavaVersion0();
+
+    private static boolean isMatlab0() {
+        try {
+            // Check whether the JMI (Java Matlab Interface - jmi.jar) is on the class path.
+            Class.forName("com.mathworks.jmi.Matlab", true, PlatformInfo.class.getClassLoader());
+            return true;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+    private static int getMajorJavaVersion0() {
+        // Default Android to Java6
+        if (isAndroid()) return 6;
+
+        // 1.6, 1.7, 1.8, 9, 10, ...
+        String version = System.getProperty("java.specification.version", "6");
+        String majorVersion = version.startsWith("1.") ? version.substring(2) : version;
+        return Integer.parseInt(majorVersion);
+    }
+
+    private PlatformInfo() {
+    }
+
+}

--- a/io/src/main/java/us/hebi/matlab/io/mat/MatChar.java
+++ b/io/src/main/java/us/hebi/matlab/io/mat/MatChar.java
@@ -2,7 +2,6 @@ package us.hebi.matlab.io.mat;
 
 import us.hebi.matlab.io.types.AbstractCharBase;
 import us.hebi.matlab.io.types.Sink;
-import us.hebi.matlab.common.memory.Resources;
 
 import java.io.IOException;
 import java.nio.CharBuffer;
@@ -47,7 +46,6 @@ class MatChar extends AbstractCharBase implements Mat5Serializable {
 
     @Override
     public void close() {
-        Resources.release(buffer);
     }
 
     @Override

--- a/io/src/test/java/us/hebi/matlab/common/memory/ResourcesTest.java
+++ b/io/src/test/java/us/hebi/matlab/common/memory/ResourcesTest.java
@@ -1,0 +1,67 @@
+package us.hebi.matlab.common.memory;
+
+import org.junit.Test;
+import us.hebi.matlab.common.util.PlatformInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Florian Enner < florian @ hebirobotics.com >
+ * @since 20 Oct 2018
+ */
+public class ResourcesTest {
+
+    @Test
+    public void releaseHeapBuffer() {
+        // Should be NO-OP
+        ByteBuffer buffer = ByteBuffer.allocate(4);
+        buffer.putInt(0, 1);
+        Resources.release(buffer);
+        buffer.putInt(0, 2);
+    }
+
+    @Test
+    public void releaseDirectBuffer() {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(1024);
+        buffer.putInt(0, 1);
+        Resources.release(buffer);
+        // Accessing again throws segfault that can't be caught
+    }
+
+    @Test
+    public void unmapMemoryMappedFile() throws IOException {
+        // Make sure file is gone
+        File tmpFile = new File("ResourcesTest.tmp");
+        assertTrue("pre-create", !tmpFile.exists() || tmpFile.delete());
+
+        // Create new file
+        final FileChannel channel = new RandomAccessFile(tmpFile, "rw").getChannel();
+        assertTrue("post-create", tmpFile.exists());
+
+        // Map to memory
+        final ByteBuffer buffer = channel
+                .map(FileChannel.MapMode.READ_WRITE, 0, 1024)
+                .load();
+
+        if (PlatformInfo.isWindows()) {
+            // Windows keeps open files from being deleted
+            assertFalse("pre-close", tmpFile.delete());
+            channel.close();
+            assertFalse("post-close", tmpFile.delete());
+        } else {
+            // Linux doesn't
+            channel.close();
+        }
+
+        // Unmap memory
+        Resources.release(buffer);
+        assertTrue("post-release", tmpFile.delete());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <name>MatlabTools Parent</name>
     <description>
-    Contains Java libraries for interfacing with MATLAB
+        Contains Java libraries for interfacing with MATLAB
     </description>
 
     <!-- Modules -->
@@ -25,11 +25,14 @@
         <!-- Other Properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- Default to minimum Java version compatible with Matlab >2009a -->
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <maven.compiler.testSource>1.8</maven.compiler.testSource>
-        <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+        <!-- Set Syntax level to Java9 so that IDEs don't complain about the module-info.java
+         and so we can use try-with-resources and Lambdas in test Syntax -->
+        <maven.compiler.source>9</maven.compiler.source>
+        <maven.compiler.target>9</maven.compiler.target>
+
+        <!-- Set the actual target to minimum Java version compatible with Matlab >2009a -->
+        <matlab.target>1.6</matlab.target>
+
     </properties>
 
     <!-- Dependency management. KEEP IN ALPHABETICAL ORDER-->
@@ -49,9 +52,83 @@
     <!-- Source code and distribution management -->
     <scm>
         <developerConnection>
-          https://github.com/ennerf/MatlabTools
+            https://github.com/ennerf/MatlabTools
         </developerConnection>
         <url>https://github.com/ennerf/MatlabTools</url>
     </scm>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+
+                <!-- Compile in 2 stages so we can get Java9 module-info w/ target sources -->
+                <!-- https://maven.apache.org/plugins/maven-compiler-plugin/examples/module-info.html -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                    <executions>
+
+                        <!-- 1) default-compile: Compile everything w/ Java 9 to make sure the module-info is correct -->
+                        <!-- (called implicitly) -->
+
+                        <!-- 2) default-testCompile: Compile tests w/ Java 9 so we can use advanced syntax -->
+                        <!-- (called implicitly) -->
+
+                        <!-- 3) Re-compile everything for target VM except the module-info.java -->
+                        <execution>
+                            <id>target-compile</id>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <!-- Note:
+                                Do not set "<release>6</release>" as that disables jdk.unsupported! It will also
+                                ignore the module-info.java file as well as disable the manual 'add-module' compiler
+                                argument, which makes it impossible to use sun.misc.Unsafe. After a lot of tinkering,
+                                the only way I got it to work was to have an existing module-info from the previous
+                                compilation step, and to revert to just using the 'target' & 'source' options. -->
+                                <source>${matlab.target}</source>
+                                <target>${matlab.target}</target>
+                                <excludes>
+                                    <exclude>module-info.java</exclude>
+                                </excludes>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <profiles>
+        <!-- Java < 9: ignore module-info-->
+        <profile>
+            <id>noJava9</id>
+            <activation>
+                <!-- https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html -->
+                <!--<jdk>(,9)</jdk>--> <!-- makes IntelliJ 2018.2 always default to 1.6 sources, so do manually -->
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <version>3.8.0</version>
+                            <configuration>
+                                <excludes>
+                                    <exclude>module-info.java</exclude>
+                                </excludes>
+                                <source>${matlab.target}</source>
+                                <target>${matlab.target}</target>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
* Added Java 9 `module-info.java` and added Java 9 implementation for releasing direct buffers
* Added cross-platform build tests for JDK 8 and JDK 9
* Kept sources to be backwards compatible with Java 6

Note that this also enables using Java 8 syntax in tests. The whole project is now set to Java 9 syntax, so we need to be more careful to not use Java >6 features (will be caught in CI) or libraries (won't be caught).