### PR TITLE
Added getNumNonZero()

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,7 @@
 
 == 0.5.3 (SNAPSHOT)
 * Fixed a bug that caused some sparse matrices to fail (nzMax > numNz). Thanks @mephenor
+* Added `getNumNonZero()` to sparse interface and deprecated `getNzMax()`. This is equivalent to MATLAB's `nnz`.
 
 == 0.5.2
 

--- a/mfl-core/src/main/java/us/hebi/matlab/mat/format/Mat5ArrayFlags.java
+++ b/mfl-core/src/main/java/us/hebi/matlab/mat/format/Mat5ArrayFlags.java
@@ -23,6 +23,8 @@ package us.hebi.matlab.mat.format;
 import us.hebi.matlab.mat.format.Mat5Serializable.Mat5Attributes;
 import us.hebi.matlab.mat.types.*;
 
+import static us.hebi.matlab.mat.util.Preconditions.*;
+
 /**
  * Utilities to deal with the int[2] array flags that are
  * at the beginning of each array.
@@ -37,10 +39,11 @@ class Mat5ArrayFlags {
             Mat5Attributes attr = ((Mat5Attributes) array);
             return create(array.getType(), global, attr.isLogical(), attr.isComplex(), attr.getNzMax());
         }
+        checkArgument(!(array instanceof Sparse), "Sparse matrices must implement Mat5Attributes");
+
         boolean logical = array instanceof Matrix && ((Matrix) array).isLogical();
         boolean complex = array instanceof Matrix && ((Matrix) array).isComplex();
-        int nzMax = array instanceof Sparse ? ((Sparse) array).getNzMax() : 0;
-        return Mat5ArrayFlags.create(array.getType(), global, logical, complex, nzMax);
+        return Mat5ArrayFlags.create(array.getType(), global, logical, complex, 0);
     }
 
     /**

--- a/mfl-core/src/main/java/us/hebi/matlab/mat/format/MatSparseCSC.java
+++ b/mfl-core/src/main/java/us/hebi/matlab/mat/format/MatSparseCSC.java
@@ -44,7 +44,7 @@ import static us.hebi.matlab.mat.util.Preconditions.*;
  * @author Florian Enner
  * @since 29 Aug 2018
  */
-class MatSparseCSC extends AbstractSparse implements Sparse, Mat5Serializable {
+class MatSparseCSC extends AbstractSparse implements Sparse, Mat5Serializable, Mat5Serializable.Mat5Attributes {
 
     MatSparseCSC(int[] dims, boolean logical, int nzMax,
                  NumberStore real,
@@ -157,6 +157,11 @@ class MatSparseCSC extends AbstractSparse implements Sparse, Mat5Serializable {
     @Override
     public int getNzMax() {
         return nzMax;
+    }
+
+    @Override
+    public int getNumNonZero() {
+        return real.getNumElements();
     }
 
     @Override

--- a/mfl-core/src/main/java/us/hebi/matlab/mat/types/AbstractSparse.java
+++ b/mfl-core/src/main/java/us/hebi/matlab/mat/types/AbstractSparse.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,6 +28,12 @@ public abstract class AbstractSparse extends AbstractMatrixBase implements Spars
 
     protected AbstractSparse(int[] dims) {
         super(dims);
+    }
+
+    @Override
+    @Deprecated
+    public int getNzMax() {
+        return getNumNonZero();
     }
 
     @Override

--- a/mfl-core/src/main/java/us/hebi/matlab/mat/types/Sparse.java
+++ b/mfl-core/src/main/java/us/hebi/matlab/mat/types/Sparse.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,15 +41,21 @@ public interface Sparse extends Matrix {
      * typically the same as the actual number of non-zero elements,
      * but this not always the case.
      * <p>
-     * NOTE: This behavior is tied to the way empty sparse matrices are
-     * stored in the MAT 5 format, so it may make sense to deprecate this
-     * method and replace it with a `getNumNz()` method. It doesn't seem
-     * particularly useful to expose a value that may be an arbitrary amount
-     * larger than necessary.
+     * NOTE: This value is an implementation detail of how the MAT 5 format
+     * stores sparse matrices and will be removed from this API in future
+     * versions. For most cases you should use getNumNonZero() instead.
      *
-     * @return maximum number of non-zero elements
+     * @return a value equal or larger than the number of non-zero elements
      */
+    @Deprecated // use getNumNonZero() instead
     int getNzMax();
+
+    /**
+     * Number of non zero matrix elements. Equivalent to 'nnz(sparse)' in MATLAB.
+     *
+     * @return the number of non-zero elements
+     */
+    int getNumNonZero();
 
     double getDefaultValue();
 

--- a/mfl-core/src/test/java/us/hebi/matlab/mat/tests/mat5/ArrayReadTest.java
+++ b/mfl-core/src/test/java/us/hebi/matlab/mat/tests/mat5/ArrayReadTest.java
@@ -26,7 +26,6 @@ import us.hebi.matlab.mat.types.*;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
 import static us.hebi.matlab.mat.format.Mat5.*;
@@ -133,6 +132,7 @@ public class ArrayReadTest {
         Sparse sparse = matFile.getSparse("s");
         assertArrayEquals(new int[]{1000000, 10000000}, sparse.getDimensions());
         assertEquals(1, sparse.getNzMax()); // for some reason nzMax is always >0
+        assertEquals(0, sparse.getNumNonZero());
         assertEquals(0, sparse.getLong(10000, 18000));
     }
 
@@ -152,6 +152,7 @@ public class ArrayReadTest {
             fail("Expected Matrix to be empty");
         });
         assertEquals(1, sparse2018b.getNzMax());
+        assertEquals(0, sparse2018b.getNumNonZero());
         assertEquals(sparse2017b, sparse2018b);
     }
 
@@ -339,26 +340,12 @@ public class ArrayReadTest {
 
         Sparse S = data.getSparse("S");
         assertEquals(3363, S.getNzMax());
-        assertEquals(3363, getNumSparseElements(S));
+        assertEquals(3363, S.getNumNonZero());
 
         Sparse rxnGeneMat = data.getSparse("rxnGeneMat");
         assertEquals(961, rxnGeneMat.getNzMax());
-        assertEquals(954, getNumSparseElements(rxnGeneMat));
+        assertEquals(954, rxnGeneMat.getNumNonZero());
 
-    }
-
-    /**
-     * Helper function to determine actual number of non-zero elements, given
-     * that nzMax may not always be the same.
-     * TODO: The API should expose this directly
-     *
-     * @param sparse
-     * @return
-     */
-    private static int getNumSparseElements(Sparse sparse) {
-        AtomicInteger count = new AtomicInteger(0);
-        sparse.forEach((row, col, real, imaginary) -> count.incrementAndGet());
-        return count.get();
     }
 
     @Test

--- a/mfl-ejml/src/main/java/us/hebi/matlab/mat/ejml/AbstractSparseWrapper.java
+++ b/mfl-ejml/src/main/java/us/hebi/matlab/mat/ejml/AbstractSparseWrapper.java
@@ -1,0 +1,76 @@
+package us.hebi.matlab.mat.ejml;
+
+import us.hebi.matlab.mat.format.Mat5Type;
+import us.hebi.matlab.mat.types.MatlabType;
+import us.hebi.matlab.mat.types.Sink;
+
+import java.io.IOException;
+
+/**
+ * @author Florian Enner
+ * @since 04 Jul 2019
+ */
+abstract class AbstractSparseWrapper<M extends org.ejml.data.MatrixSparse> extends AbstractMatrixWrapper<M> {
+
+    AbstractSparseWrapper(M matrix) {
+        super(matrix);
+    }
+
+    @Override
+    protected int getMat5DataSize() {
+        return Mat5Type.Int32.computeSerializedSize(getNumRowIndices())
+                + Mat5Type.Int32.computeSerializedSize(getNumColIndices())
+                + getMat5SparseNonZeroDataSize();
+    }
+
+    protected abstract int getMat5SparseNonZeroDataSize();
+
+    @Override
+    protected void writeMat5Data(Sink sink) throws IOException {
+        // Row indices (always at least 1)
+        Mat5Type.Int32.writeTag(getNumRowIndices(), sink);
+        sink.writeInts(getRowIndices0(), 0, getNumRowIndices());
+        Mat5Type.Int32.writePadding(getNumRowIndices(), sink);
+
+        // Column indices
+        Mat5Type.Int32.writeTag(getNumColIndices(), sink);
+        sink.writeInts(getColIndices(), 0, getNumColIndices());
+        Mat5Type.Int32.writePadding(getNumColIndices(), sink);
+
+        // Data portion
+        writeMat5SparseNonZeroData(sink);
+    }
+
+    protected abstract void writeMat5SparseNonZeroData(Sink sink) throws IOException;
+
+    @Override
+    public MatlabType getType() {
+        return MatlabType.Sparse;
+    }
+
+    public int getNzMax() {
+        // MATLAB sparse are always at least 1 element
+        return Math.max(1, matrix.getNonZeroLength());
+    }
+
+    private int getNumRowIndices() {
+        // Must always match nz max
+        return getNzMax();
+    }
+
+    private int[] getRowIndices0() {
+        // Returns row index array or an empty 1 element array to match nzMax()
+        return matrix.getNonZeroLength() == 0 ? EMPTY_ROW_INDEX : getRowIndices();
+    }
+
+    private int getNumColIndices() {
+        return matrix.getNumCols() + 1;
+    }
+
+    protected abstract int[] getRowIndices();
+
+    protected abstract int[] getColIndices();
+
+    private static final int[] EMPTY_ROW_INDEX = new int[1]; // MATLAB expects at least on element
+
+}

--- a/mfl-ejml/src/main/java/us/hebi/matlab/mat/ejml/DMatrixSparseCSCWrapper.java
+++ b/mfl-ejml/src/main/java/us/hebi/matlab/mat/ejml/DMatrixSparseCSCWrapper.java
@@ -22,7 +22,6 @@ package us.hebi.matlab.mat.ejml;
 
 import org.ejml.data.DMatrixSparseCSC;
 import us.hebi.matlab.mat.format.Mat5Type;
-import us.hebi.matlab.mat.types.MatlabType;
 import us.hebi.matlab.mat.types.Sink;
 
 import java.io.IOException;
@@ -32,31 +31,15 @@ import java.io.IOException;
  *
  * @author Florian Enner
  */
-class DMatrixSparseCSCWrapper extends AbstractMatrixWrapper<DMatrixSparseCSC> {
+class DMatrixSparseCSCWrapper extends AbstractSparseWrapper<DMatrixSparseCSC> {
 
     @Override
-    protected int getMat5DataSize() {
-        return Mat5Type.Int32.computeSerializedSize(getNumRowIndices())
-                + Mat5Type.Int32.computeSerializedSize(getNumColIndices())
-                + Mat5Type.Double.computeSerializedSize(matrix.getNonZeroLength());
+    protected int getMat5SparseNonZeroDataSize() {
+        return Mat5Type.Double.computeSerializedSize(matrix.getNonZeroLength());
     }
 
     @Override
-    protected void writeMat5Data(Sink sink) throws IOException {
-        // Row indices (MATLAB requires at least 1 entry)
-        Mat5Type.Int32.writeTag(getNumRowIndices(), sink);
-        if (matrix.getNonZeroLength() == 0) {
-            sink.writeInt(0);
-        } else {
-            sink.writeInts(matrix.nz_rows, 0, getNumRowIndices());
-        }
-        Mat5Type.Int32.writePadding(getNumRowIndices(), sink);
-
-        // Column indices
-        Mat5Type.Int32.writeTag(getNumColIndices(), sink);
-        sink.writeInts(matrix.col_idx, 0, getNumColIndices());
-        Mat5Type.Int32.writePadding(getNumColIndices(), sink);
-
+    protected void writeMat5SparseNonZeroData(Sink sink) throws IOException {
         // Non-zero values
         Mat5Type.Double.writeTag(matrix.getNonZeroLength(), sink);
         sink.writeDoubles(matrix.nz_values, 0, matrix.getNonZeroLength());
@@ -64,13 +47,13 @@ class DMatrixSparseCSCWrapper extends AbstractMatrixWrapper<DMatrixSparseCSC> {
     }
 
     @Override
-    public MatlabType getType() {
-        return MatlabType.Sparse;
+    protected int[] getRowIndices() {
+        return matrix.nz_rows;
     }
 
     @Override
-    public int getNzMax() {
-        return Math.max(1, matrix.getNonZeroLength());
+    protected int[] getColIndices() {
+        return matrix.col_idx;
     }
 
     DMatrixSparseCSCWrapper(DMatrixSparseCSC matrix) {
@@ -78,14 +61,6 @@ class DMatrixSparseCSCWrapper extends AbstractMatrixWrapper<DMatrixSparseCSC> {
         if (!matrix.indicesSorted) {
             matrix.sortIndices(null);
         }
-    }
-
-    private int getNumRowIndices() {
-        return getNzMax();
-    }
-
-    private int getNumColIndices() {
-        return matrix.getNumCols() + 1;
     }
 
 }

--- a/mfl-ejml/src/main/java/us/hebi/matlab/mat/ejml/SparseToCscConverter.java
+++ b/mfl-ejml/src/main/java/us/hebi/matlab/mat/ejml/SparseToCscConverter.java
@@ -56,7 +56,7 @@ abstract class SparseToCscConverter implements Sparse.SparseConsumer {
     static class SparseToFCscConverter extends SparseToCscConverter {
 
         void convertToFSparseCSC(Sparse input, FMatrixSparseCSC output) {
-            output.reshape(input.getNumRows(), input.getNumCols(), input.getNzMax());
+            output.reshape(input.getNumRows(), input.getNumCols(), input.getNumNonZero());
             initializeConversion(output.col_idx, output.nz_rows, output.nz_values, null);
             input.forEach(this);
             finishConversion(output.getNumCols());
@@ -73,7 +73,7 @@ abstract class SparseToCscConverter implements Sparse.SparseConsumer {
     static class SparseToDCscConverter extends SparseToCscConverter {
 
         void convertToDSparseCSC(Sparse input, DMatrixSparseCSC output) {
-            output.reshape(input.getNumRows(), input.getNumCols(), input.getNzMax());
+            output.reshape(input.getNumRows(), input.getNumCols(), input.getNumNonZero());
             initializeConversion(output.col_idx, output.nz_rows, null, output.nz_values);
             input.forEach(this);
             finishConversion(output.getNumCols());


### PR DESCRIPTION
`getNzMax()` returns a number that is equal **or larger** than `getNumNonZero()`. In most cases this is an irrelevant implementation detail.

The `getNumNonZero()` is equivalent to MATLAB's `nnz()` and always returns the exact number of non-zero values. The old `getNzMax()` has been deprecated and will be removed in a future release.

This fixes issue #37. 