### PR TITLE
Write default subsystem offset as zero

### DIFF
--- a/mfl-core/src/main/java/us/hebi/matlab/mat/format/Mat5Writer.java
+++ b/mfl-core/src/main/java/us/hebi/matlab/mat/format/Mat5Writer.java
@@ -220,9 +220,9 @@ public final class Mat5Writer {
             }
         }
         // Lastly, update subsystem offset in the (non-reduced) header
-        if (headerStart >= 0 && subsysLocation >= -1) {
+        if (headerStart >= 0 && subsysLocation > 0) {
             Mat5File.updateSubsysOffset(headerStart, subsysLocation, sink);
-            subsysLocation = -1;
+            subsysLocation = 0;
         }
         return this;
     }
@@ -238,7 +238,7 @@ public final class Mat5Writer {
     protected final Sink sink;
     protected int deflateLevel = Deflater.BEST_SPEED;
     private long headerStart = -1;
-    private long subsysLocation = -1;
+    private long subsysLocation = 0; // matlab uses zeros for missing subsystems
     private ExecutorService executorService = null;
     private BufferAllocator bufferAllocator = Mat5.getDefaultBufferAllocator();
     private final List<Future<FlushAction>> flushActions = new ArrayList<Future<FlushAction>>(16);

--- a/mfl-core/src/test/java/us/hebi/matlab/mat/tests/mat5/ArrayReadTest.java
+++ b/mfl-core/src/test/java/us/hebi/matlab/mat/tests/mat5/ArrayReadTest.java
@@ -21,9 +21,13 @@
 package us.hebi.matlab.mat.tests.mat5;
 
 import org.junit.Test;
+import us.hebi.matlab.mat.format.Mat5;
+import us.hebi.matlab.mat.format.Mat5File;
 import us.hebi.matlab.mat.types.*;
 
 import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -450,6 +454,17 @@ public class ArrayReadTest {
         assertEquals(1, uint8(matFile.getMatrix(0).getByte(0)));
         assertEquals(2, uint8(matFile.getMatrix(1).getByte(0)));
         assertEquals(3, uint8(matFile.getMatrix(2).getByte(0)));
+    }
+
+    @Test
+    public void testEmptySubsystem() throws Exception {
+        MatFile out = Mat5.newMatFile()
+                .addArray("var1", Mat5.newScalar(7));
+        ByteBuffer bytes = MatTestUtil.toBinaryForm(out, ByteOrder.nativeOrder());
+        bytes.flip();
+        Mat5File in = MatTestUtil.fromBinaryForm(bytes);
+        assertEquals(out, in);
+        assertEquals(0, in.getSubsysOffset());
     }
 
 }

--- a/mfl-core/src/test/java/us/hebi/matlab/mat/tests/mat5/MatTestUtil.java
+++ b/mfl-core/src/test/java/us/hebi/matlab/mat/tests/mat5/MatTestUtil.java
@@ -44,6 +44,21 @@ import static us.hebi.matlab.mat.util.Preconditions.*;
  */
 public class MatTestUtil {
 
+    public static ByteBuffer toBinaryForm(MatFile matFile, ByteOrder order) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate((int) matFile.getUncompressedSerializedSize());
+        buffer.order(order);
+        try (Sink sink = Sinks.wrap(buffer)) {
+            matFile.writeTo(sink);
+        }
+        return buffer;
+    }
+
+    public static Mat5File fromBinaryForm(ByteBuffer buffer) throws IOException {
+        try (Source source = Sources.wrap(buffer)) {
+            return Mat5.newReader(source).readMat();
+        }
+    }
+
     public static Mat5File readMat(String name) throws IOException {
         return readMat(name, testRoundTrip);
     }


### PR DESCRIPTION
This fixes a bug where missing subsystems were erroneously written as `-1` rather than `0`.