### PR TITLE
McosFileWrapper now allows v5

### DIFF
--- a/mfl-core/src/main/java/us/hebi/matlab/mat/format/McosFileWrapper.java
+++ b/mfl-core/src/main/java/us/hebi/matlab/mat/format/McosFileWrapper.java
@@ -75,8 +75,8 @@ class McosFileWrapper extends MatOpaque {
 
         // Version
         version = buffer.getInt();
-        if (version < 2 || version > 4)
-            throw readError("MAT file's MCOS data has an unknown version. Expected: 2 through 4, Found %d", version);
+        if (version < 2 || version > 5)
+            throw readError("MAT file's MCOS data has an unknown version. Expected: 2 through 5, Found %d", version);
 
         // String count
         int numStrings = buffer.getInt();


### PR DESCRIPTION
A file with version 5 exists in the examples directory of Matlab R2022b (specifically `examples/simulink_variants/main/topData.sldd`). I can't figure out how to create a file like this from scratch, so I can't provide an example that meets the Apache license. But after bumping these simple version numbers, the correct fields show up!